### PR TITLE
feat: breadcrumb navigation pattern for nested routes

### DIFF
--- a/docs/uiux/breadcrumb-navigation.md
+++ b/docs/uiux/breadcrumb-navigation.md
@@ -1,0 +1,69 @@
+# Breadcrumb Navigation Pattern
+
+## References
+
+- Issue: `#185`
+- Component: `src/components/Breadcrumb.tsx`
+- Routes: `/attestations/:id`, `/onboarding`
+
+## Goal
+
+Provide a lightweight secondary wayfinding aid that tells users where they are within a nested route without competing with the sidebar's primary navigation. Breadcrumbs appear only on detail and wizard views — not on top-level pages where the sidebar active state is sufficient.
+
+## When to Show a Breadcrumb
+
+| Context | Breadcrumb trail |
+|---|---|
+| Attestation detail | Attestations › Attestation {id} |
+| Onboarding wizard | Dashboard › Onboarding › {step title} |
+
+Do not add a breadcrumb to top-level pages (Dashboard, Attestations list, Settings). The sidebar already conveys location there.
+
+## Placement
+
+- Render directly above the page `<h1>`, outside any card or panel.
+- Use a standard `<nav aria-label="Breadcrumb">` wrapping an `<ol>` so assistive technology identifies the landmark separately from the main navigation sidebar.
+- Margin below the breadcrumb is `1rem` to maintain vertical rhythm before the heading.
+
+## Truncation Rules
+
+Long route labels (e.g. a business name used as a step title) must not overflow the breadcrumb row or push the separator off-screen.
+
+- **Default limit:** 24 characters per crumb label.
+- Labels that exceed the limit are cut to 23 characters and appended with `…` (U+2026 HORIZONTAL ELLIPSIS).
+- The full label is exposed via the `title` attribute on the element so pointer users can hover to read it. Screen readers receive the untruncated label through `aria-label` on the link or the visible `title`.
+- The `maxLabelLength` prop on `<Breadcrumb>` can be overridden per call-site for layouts with more horizontal space.
+
+### Examples
+
+| Full label | Displayed (max 24) |
+|---|---|
+| `Business details` | `Business details` (no truncation) |
+| `Document upload and verification` | `Document upload and verificat…` |
+| `att-001` | `att-001` (no truncation) |
+
+## Interaction and Visual Design
+
+- All crumbs except the last are `<Link>` elements styled with the primary brand colour.
+- The last crumb (current page) is a `<span aria-current="page">` with muted colour — it is not a link.
+- Separator `/` is `aria-hidden="true"` so screen readers only hear `Attestations, Attestation att-001` rather than `Attestations slash Attestation att-001`.
+- Focus and hover: ancestor links show an underline on hover. No extra ring needed — the browser default focus outline is preserved.
+
+## Accessibility
+
+- The `<nav>` landmark uses `aria-label="Breadcrumb"` to distinguish it from the sidebar `<nav aria-label="Main navigation">`.
+- `aria-current="page"` on the final item allows screen readers to announce the current location without requiring separate visually-hidden text.
+- Truncated labels always carry a `title` attribute so users with low vision who enlarge text can still discover the full string via tooltip.
+- The component does not render if `items` is empty — this prevents an empty `<nav>` from appearing in the accessibility tree.
+
+## Sidebar Coexistence
+
+- The breadcrumb does not duplicate the sidebar's active link highlight. It adds depth information (which record or which step) that the sidebar cannot express.
+- On mobile, the sidebar collapses into a hamburger. The breadcrumb remains visible above the page heading so users always know their location regardless of sidebar state.
+- Do not place the breadcrumb inside the sidebar or the top app bar. It belongs to the page content region (`<main>`).
+
+## Edge States
+
+- **Single item:** If only one item is passed (unusual — avoid this), render it as a non-linked `aria-current="page"` span with no separator.
+- **Missing `href`:** A crumb without an `href` renders as a plain `<span>` rather than a dead `<a>`. This is intentional for the current-page crumb and for any intermediate step that cannot be deep-linked.
+- **Very long IDs:** Attestation IDs are truncated to the configured limit. The full ID remains accessible via `title` and in the `<h1>` below.

--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -1,0 +1,55 @@
+import { Link } from 'react-router-dom'
+
+export interface BreadcrumbItem {
+  label: string
+  href?: string
+}
+
+interface BreadcrumbProps {
+  items: BreadcrumbItem[]
+  /** Max characters before a crumb label is truncated with an ellipsis. Default: 24 */
+  maxLabelLength?: number
+}
+
+function truncateLabel(label: string, max: number): { display: string; truncated: boolean } {
+  if (label.length <= max) return { display: label, truncated: false }
+  return { display: label.slice(0, max - 1) + '…', truncated: true }
+}
+
+export default function Breadcrumb({ items, maxLabelLength = 24 }: BreadcrumbProps) {
+  return (
+    <nav aria-label="Breadcrumb" className="breadcrumb">
+      <ol className="breadcrumb-list">
+        {items.map((item, index) => {
+          const isLast = index === items.length - 1
+          const { display, truncated } = truncateLabel(item.label, maxLabelLength)
+
+          return (
+            <li key={index} className="breadcrumb-item">
+              {!isLast && item.href ? (
+                <Link
+                  to={item.href}
+                  className="breadcrumb-link"
+                  title={truncated ? item.label : undefined}
+                >
+                  {display}
+                </Link>
+              ) : (
+                <span
+                  aria-current={isLast ? 'page' : undefined}
+                  className="breadcrumb-current"
+                  title={truncated ? item.label : undefined}
+                >
+                  {display}
+                </span>
+              )}
+              {!isLast && (
+                <span className="breadcrumb-separator" aria-hidden="true">/</span>
+              )}
+            </li>
+          )
+        })}
+      </ol>
+    </nav>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -3278,3 +3278,51 @@ input {
     gap: 0.75rem;
   }
 }
+
+/* ─── Breadcrumb ─────────────────────────────────────────────────────────── */
+.breadcrumb {
+  margin-bottom: 1rem;
+}
+
+.breadcrumb-list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: 0.875rem;
+}
+
+.breadcrumb-item {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.breadcrumb-link {
+  color: var(--color-primary, #6366f1);
+  text-decoration: none;
+  white-space: nowrap;
+  max-width: 16rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.breadcrumb-link:hover {
+  text-decoration: underline;
+}
+
+.breadcrumb-current {
+  color: var(--color-text-muted, #71717a);
+  white-space: nowrap;
+  max-width: 16rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.breadcrumb-separator {
+  color: var(--color-text-muted, #71717a);
+  user-select: none;
+}

--- a/src/pages/AttestationDetail.tsx
+++ b/src/pages/AttestationDetail.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useParams, Link } from 'react-router-dom'
+import Breadcrumb from '../components/Breadcrumb'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -206,7 +207,7 @@ export default function AttestationDetail() {
   if (!attestation) {
     return (
       <div>
-        <BackLink />
+        <Breadcrumb items={[{ label: 'Attestations', href: '/attestations' }, { label: id }]} />
         <div
           role="alert"
           aria-live="polite"
@@ -229,7 +230,12 @@ export default function AttestationDetail() {
 
   return (
     <div style={{ maxWidth: '52rem' }}>
-      <BackLink />
+      <Breadcrumb
+        items={[
+          { label: 'Attestations', href: '/attestations' },
+          { label: `Attestation ${attestation.id}` },
+        ]}
+      />
 
       {/* ── Header ─────────────────────────────────────────────────────── */}
       <header

--- a/src/pages/OnboardingWizard.tsx
+++ b/src/pages/OnboardingWizard.tsx
@@ -8,6 +8,7 @@ import type { FileMap } from './onboarding/DocumentUploadStep'
 import BankDetailsStep from './onboarding/BankDetailsStep'
 import ReviewSubmitStep from './onboarding/ReviewSubmitStep'
 import type { BusinessDetails, OwnerDetails, DocumentUpload, BankDetails } from '../hooks/useOnboardingDraft'
+import Breadcrumb from '../components/Breadcrumb'
 
 const TOTAL_STEPS = 5
 
@@ -91,6 +92,15 @@ export default function OnboardingWizard() {
   return (
     <main className="ob-page">
       <div className="ob-shell">
+        {/* Breadcrumb */}
+        <Breadcrumb
+          items={[
+            { label: 'Dashboard', href: '/dashboard' },
+            { label: 'Onboarding' },
+            { label: meta.title },
+          ]}
+        />
+
         {/* Top bar */}
         <div className="ob-topbar">
           <Link to="/" className="ob-brand">Veritasor</Link>

--- a/src/test/breadcrumb.test.tsx
+++ b/src/test/breadcrumb.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import Breadcrumb from '../components/Breadcrumb'
+
+function renderBreadcrumb(props: React.ComponentProps<typeof Breadcrumb>) {
+  return render(
+    <MemoryRouter>
+      <Breadcrumb {...props} />
+    </MemoryRouter>
+  )
+}
+
+describe('Breadcrumb', () => {
+  it('renders a nav landmark with label "Breadcrumb"', () => {
+    renderBreadcrumb({ items: [{ label: 'Home', href: '/' }, { label: 'Detail' }] })
+    expect(screen.getByRole('navigation', { name: 'Breadcrumb' })).toBeInTheDocument()
+  })
+
+  it('renders ancestor crumbs as links', () => {
+    renderBreadcrumb({ items: [{ label: 'Attestations', href: '/attestations' }, { label: 'att-001' }] })
+    expect(screen.getByRole('link', { name: 'Attestations' })).toHaveAttribute('href', '/attestations')
+  })
+
+  it('renders the last crumb as aria-current="page" and not a link', () => {
+    renderBreadcrumb({ items: [{ label: 'Attestations', href: '/attestations' }, { label: 'att-001' }] })
+    const current = screen.getByText('att-001')
+    expect(current.tagName).toBe('SPAN')
+    expect(current).toHaveAttribute('aria-current', 'page')
+    expect(screen.queryByRole('link', { name: 'att-001' })).not.toBeInTheDocument()
+  })
+
+  it('renders separators between crumbs', () => {
+    renderBreadcrumb({ items: [{ label: 'A', href: '/a' }, { label: 'B', href: '/b' }, { label: 'C' }] })
+    const separators = document.querySelectorAll('.breadcrumb-separator')
+    // 3 items → 2 separators (before items 2 and 3)
+    expect(separators).toHaveLength(2)
+  })
+
+  it('truncates labels exceeding maxLabelLength', () => {
+    const longLabel = 'Document upload and verification'
+    renderBreadcrumb({ items: [{ label: longLabel }], maxLabelLength: 24 })
+    // slice(0, 23) + '…' = "Document upload and ver…"
+    expect(screen.getByText('Document upload and ver…')).toBeInTheDocument()
+  })
+
+  it('does not truncate labels within maxLabelLength', () => {
+    renderBreadcrumb({ items: [{ label: 'Business details' }], maxLabelLength: 24 })
+    expect(screen.getByText('Business details')).toBeInTheDocument()
+  })
+
+  it('adds title attribute to truncated crumbs', () => {
+    const longLabel = 'A very long label that exceeds the limit'
+    renderBreadcrumb({ items: [{ label: longLabel }], maxLabelLength: 20 })
+    const el = screen.getByTitle(longLabel)
+    expect(el).toBeInTheDocument()
+  })
+
+  it('does not add title attribute when label fits within limit', () => {
+    renderBreadcrumb({ items: [{ label: 'Short label' }], maxLabelLength: 24 })
+    expect(document.querySelector('[title]')).toBeNull()
+  })
+
+  it('renders a single crumb as aria-current="page" with no link', () => {
+    renderBreadcrumb({ items: [{ label: 'Only' }] })
+    const el = screen.getByText('Only')
+    expect(el).toHaveAttribute('aria-current', 'page')
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  })
+
+  it('renders a crumb without href as a span even when not last', () => {
+    // Middle crumb with no href should not be a link
+    renderBreadcrumb({ items: [{ label: 'Home' }, { label: 'Middle' }, { label: 'Current' }] })
+    // 'Home' has no href — should be a span (not a link)
+    expect(screen.queryByRole('link', { name: 'Home' })).not.toBeInTheDocument()
+    expect(screen.getByText('Home').tagName).toBe('SPAN')
+  })
+
+  it('uses default maxLabelLength of 24 when not provided', () => {
+    // Exactly 24 chars — should not truncate
+    const label = 'A'.repeat(24)
+    renderBreadcrumb({ items: [{ label }] })
+    expect(screen.getByText(label)).toBeInTheDocument()
+
+    // 25 chars — should truncate
+    const longLabel = 'A'.repeat(25)
+    const { unmount } = renderBreadcrumb({ items: [{ label: longLabel }] })
+    expect(screen.getByText('A'.repeat(23) + '…')).toBeInTheDocument()
+    unmount()
+  })
+})


### PR DESCRIPTION
## Summary

Implements the breadcrumb navigation pattern for nested routes (attestation detail, onboarding wizard steps) as described in issue #185.

## Changes

- **`src/components/Breadcrumb.tsx`** — New reusable `<Breadcrumb>` component. Accepts an `items` array of `{ label, href? }` and a `maxLabelLength` prop (default 24). Ancestor crumbs render as React Router `<Link>` elements; the current-page crumb renders as `<span aria-current="page">`. Labels exceeding the max length are truncated with `…` and the full text exposed via `title`.
- **`src/index.css`** — Breadcrumb CSS (nav, list, link, current, separator).
- **`src/pages/AttestationDetail.tsx`** — Replaces the existing `<BackLink>` with `<Breadcrumb items={[Attestations → Attestation {id}]}`.
- **`src/pages/OnboardingWizard.tsx`** — Adds `<Breadcrumb items={[Dashboard → Onboarding → {step title}]}` above the top bar.
- **`docs/uiux/breadcrumb-navigation.md`** — UX doc covering placement rules, truncation spec, sidebar coexistence, accessibility requirements, and edge states.
- **`src/test/breadcrumb.test.tsx`** — 11 tests covering: nav landmark, link rendering, aria-current, separators, truncation, title attribute, single crumb, no-href crumb, and default maxLabelLength.

## Testing

All 11 breadcrumb tests pass (`npm test -- --run src/test/breadcrumb.test.tsx`).

> Note: There is a pre-existing TypeScript error in `src/pages/Attestations.tsx` (JSX tag mismatch at line 516–518) that is present on `main` before this branch and is unrelated to these changes.

Closes #185