### PR TITLE
design: pagination and load-more pattern

### DIFF
--- a/docs/uiux/pagination-load-more-pattern.md
+++ b/docs/uiux/pagination-load-more-pattern.md
@@ -1,0 +1,169 @@
+# Pagination & Load-More Pattern
+
+## References
+
+- Issue: `#195`
+- Component: `src/components/Pagination.tsx`
+- Hooks: `src/hooks/usePagination.ts`, `src/hooks/useIsMobile.ts`
+- Applied to: `src/pages/Attestations.tsx`
+
+## Goal
+
+Provide one unified pattern for paging through long lists that works the same
+way everywhere it's used: numbered pages with a page-size selector on
+dense/desktop screens, and a single progressive "Load more" control on
+mobile — both driven by the same URL state, so a link to page 3 works
+regardless of which variant the recipient's viewport renders.
+
+## Why a single `page`/`pageSize` state for both variants
+
+Numbered pagination shows a *window* of items (`items[(page-1)*pageSize .. page*pageSize]`).
+Progressive loading shows a *cumulative* range (`items[0 .. page*pageSize]`).
+Both variants are defined here as different ways of **displaying** the same
+`page`/`pageSize` pair rather than two independent state machines:
+
+- Numbered variant renders `pagination.startIndex .. pagination.endIndex`.
+- Progressive variant renders `0 .. pagination.cumulativeEndIndex`.
+
+This means resizing from desktop (say, viewing page 3 of 10-per-page — items
+21–30) down to mobile doesn't lose your place: the progressive view shows
+items 1–30, i.e. "everything up to and including where you were." Widening
+back out returns you to the same page-3 window. One `usePagination` call, one
+URL contract, two renderings.
+
+## URL contract
+
+```
+?page=<1-based integer>     numbered: which page window is shown
+                             progressive: how many pages have been loaded so far
+?pageSize=<integer>         items per page — must be one of pageSizeOptions
+                             (default [10, 25, 50])
+```
+
+- Both params default silently (`page=1`, `pageSize=`defaultPageSize) when
+  absent, non-numeric, fractional, negative, or — for `pageSize` — not one of
+  the allowed options. A hand-edited or stale URL never throws or shows a
+  broken page.
+- If `?page` ends up beyond the last valid page (e.g. a filtered list shrank),
+  `usePagination` corrects the URL back to the last valid page via
+  `replace: true` — it does not push a new history entry, matching the
+  existing convention in `SearchFilter.tsx`'s `setParam`.
+- Changing `pageSize` resets `page` to `1`, since the previous page number no
+  longer points at the same window of items.
+
+## Desktop/dense: numbered variant
+
+- `<nav aria-label="Pagination">` with Previous/Next buttons and a windowed
+  list of page-number buttons (first, last, current ± 1 sibling, `…` for
+  gaps — see `getPageWindow` in `Pagination.tsx`). Below 8 total pages the
+  full sequential list is shown with no gaps at all.
+- The current page button carries `aria-current="page"` (no separate visible
+  "current" text needed — same approach as `Breadcrumb.tsx`).
+- An "Items per page" `<select>` (native, labelled via `<label htmlFor>`)
+  lets users pick 10/25/50 per page.
+
+## Mobile: progressive "Load more"
+
+- A single centered "Load more" button appends the next page's worth of
+  items to the list already on screen.
+- Disappears once every item has been loaded — no page-size selector on
+  mobile (manual page-size tuning isn't a mobile-tap-target-friendly control;
+  users just tap Load more).
+- The switch between variants is **JS-driven** (`useIsMobile`, a
+  `matchMedia('(max-width: 640px)')` hook mirroring `useTheme.ts`'s
+  subscribe/`addEventListener` pattern), not CSS-only. Unlike a control
+  toggle (e.g. `Settings.tsx`'s tablist ↔ mobile-`<select>` swap), pagination
+  also changes *which items are in the DOM* (a page window vs. a cumulative
+  slice) — mounting both variants and hiding one with CSS would mean
+  rendering the row list twice. Using one hook to decide both "which items"
+  and "which controls" keeps the two perfectly in sync and avoids a
+  double-mounted list.
+
+## Accessibility (WCAG 2.1 AA)
+
+- **Live announcements** — a single `role="status" aria-live="polite"
+  aria-atomic="true"` element is always mounted (never conditionally
+  rendered, so screen readers pick up the very first update) and reads:
+  - `"Showing all N {items}"` — everything fits on one page/load.
+  - `"Showing {start}–{end} of {total} {items}"` — numbered variant, page > 1.
+  - `"Showing {count} of {total} {items}"` — progressive variant, more to load.
+  - `"No {items}"` — zero items.
+  Polite, not assertive — paging is not an urgent interruption (WCAG 4.1.3).
+- **Keyboard/native semantics** — Previous/Next/page-number/Load-more are all
+  native `<button type="button">`; boundary buttons use the `disabled`
+  attribute (removed from tab order) rather than `aria-disabled`, per the
+  project's existing disabled-state rule.
+- **Ellipsis markers** are `aria-hidden="true"` — they're a visual gap
+  indicator only; no information is lost by skipping them (same reasoning as
+  `Breadcrumb.tsx`'s `aria-hidden` separator).
+- **Touch targets** — nav/page buttons and the Load-more button use
+  `min-height/min-width: var(--density-touch-min)` (44px, WCAG 2.5.5).
+- **Focus** — relies on the global `:focus-visible` ring. Fixed as part of
+  this change: `--focus-ring`/`--focus-ring-offset` were referenced by the
+  global `:focus-visible` rule in `index.css` but were never defined in
+  `:root`, so **no element in the app had a visible keyboard focus ring**.
+  Added the values already specified in `docs/accessibility-checklist.md`.
+
+## Responsive
+
+- Breakpoint: `max-width: 640px`, matching the existing mobile cutoff used
+  elsewhere in `index.css`.
+- All spacing uses density tokens (`--density-*`), so both variants respect
+  comfortable/compact density mode.
+- The page-size selector wraps to full width and centers under 640px in case
+  it's ever shown there (`showPageSizeSelector` defaults to hidden-by-variant
+  already, this is just a defensive style for a future call site).
+
+## RTL
+
+- No hardcoded directional CSS — `margin-inline-start` is used for the
+  page-size control's alignment, and the Prev/Next chevrons (`‹`/`›`) are
+  purely decorative (`aria-hidden`) glyphs read from the accessible
+  "Previous page"/"Next page" labels, not the visible glyph, so no mirroring
+  logic is required. Verified conceptually against
+  `docs/uiux/localization-layout-constraints.md`; no automated RTL screenshot
+  tooling exists in this repo to attach a rendered before/after (see
+  Screenshots below).
+
+## Edge cases
+
+- **Single page** (`totalItems <= pageSize`) — no Prev/Next/page-numbers or
+  Load-more button render at all; only the "Showing all N" announcement.
+- **Zero items** — announces "No {items}"; pages that already have their own
+  empty state (e.g. `Attestations.tsx`'s `EmptyState`) render that instead of
+  `<Pagination>` and never mount it.
+- **Very many pages** — `getPageWindow` collapses to `1 … 4 5 6 … 50`-style
+  windowing once there are more than 7 pages; first and last page are always
+  reachable in one click.
+- **Out-of-range `?page`** (e.g. a bookmarked link to page 40 after the list
+  shrank to 12 pages) — silently clamped back to the last valid page.
+- **Mobile** — see "Mobile: progressive Load more" above.
+
+## Validation checklist
+
+- `npm run lint` — no new errors (the one warning `Pagination.tsx` produces,
+  `react-refresh/only-export-components` for exporting `getPageWindow`
+  alongside the component, is the same pre-existing warning `SearchFilter.tsx`
+  already has for `parseFilterState`).
+- `npx tsc --noEmit` — introduces zero new type errors (see PR description for
+  the pre-existing, unrelated errors this repo already has on `main`).
+- Tests: `src/test/pagination.test.tsx` (hook + component, 36 cases, 100%
+  statement/branch/function/line coverage on `Pagination.tsx`,
+  `usePagination.ts`, and `useIsMobile.ts`) plus new/updated cases in
+  `src/pages/Attestations.test.tsx`.
+- Keyboard: Tab to Prev → Tab through page numbers → Tab to Next → Tab to the
+  page-size select; Enter/Space activates each button; disabled boundary
+  buttons are skipped automatically.
+- Screen reader: confirm the "Showing X–Y of Z" text is announced once,
+  politely, after each page change (not on every keystroke/render).
+
+## Screenshots
+
+> _Before/after and axe screenshots to be attached in the PR_
+> (`docs/uiux/screenshots/pagination-*.png`), following the same convention
+> as `docs/uiux/data-export-download-ux.md`. This change was authored and
+> validated in a non-graphical environment (no browser available to capture
+> screenshots); a reviewer with a running dev server should attach:
+> 1. Desktop numbered view (~24 mock attestations, page 1 of 3).
+> 2. Mobile progressive view with the Load more button.
+> 3. An axe DevTools scan of both, run after the focus-ring fix above.

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,166 @@
+import { useId } from 'react'
+import type { PaginationResult } from '../hooks/usePagination'
+import { useIsMobile } from '../hooks/useIsMobile'
+
+// ─── Public types ──────────────────────────────────────────────────────────
+
+export type PaginationProps = {
+  /** Return value of usePagination(totalItems, options) — shared with the caller's data slicing. */
+  pagination: PaginationResult
+  /** Total unfiltered/unsliced item count — used for the aria-live announcement. */
+  totalItems: number
+  /** Singular noun for the entity being paginated, e.g. "attestation". */
+  entityLabel?: string
+  /** Hide the "Items per page" selector (numbered variant only). Default: true */
+  showPageSizeSelector?: boolean
+}
+
+// ─── Page-number windowing ─────────────────────────────────────────────────
+
+/**
+ * Windowed list of page numbers with '…' gap markers, e.g.
+ * total=20, current=10, siblingCount=1 -> [1, '…', 9, 10, 11, '…', 20].
+ * Falls back to the full sequential list once it already fits without gaps.
+ */
+export function getPageWindow(current: number, total: number, siblingCount = 1): (number | '…')[] {
+  const totalNumbers = siblingCount * 2 + 5 // first + last + current + 2 siblings + 2 ellipses worth of slack
+  if (total <= totalNumbers) {
+    return Array.from({ length: total }, (_, i) => i + 1)
+  }
+
+  const left = Math.max(current - siblingCount, 2)
+  const right = Math.min(current + siblingCount, total - 1)
+  const showLeftEllipsis = left > 2
+  const showRightEllipsis = right < total - 1
+
+  const pages: (number | '…')[] = [1]
+  if (showLeftEllipsis) pages.push('…')
+  for (let i = left; i <= right; i++) pages.push(i)
+  if (showRightEllipsis) pages.push('…')
+  pages.push(total)
+  return pages
+}
+
+// ─── Component ──────────────────────────────────────────────────────────────
+
+export default function Pagination({
+  pagination,
+  totalItems,
+  entityLabel = 'result',
+  showPageSizeSelector = true,
+}: PaginationProps) {
+  const isMobile = useIsMobile()
+  const pageSizeId = useId()
+  const {
+    page,
+    pageSize,
+    pageSizeOptions,
+    totalPages,
+    startIndex,
+    endIndex,
+    cumulativeEndIndex,
+    hasMore,
+    setPage,
+    setPageSize,
+    loadMore,
+  } = pagination
+
+  const plural = `${entityLabel}s`
+  const singlePage = totalPages <= 1
+
+  let statusText: string
+  if (totalItems === 0) {
+    statusText = `No ${plural}`
+  } else if (isMobile) {
+    statusText = hasMore
+      ? `Showing ${cumulativeEndIndex} of ${totalItems} ${plural}`
+      : `Showing all ${totalItems} ${plural}`
+  } else if (singlePage) {
+    statusText = `Showing all ${totalItems} ${plural}`
+  } else {
+    statusText = `Showing ${startIndex + 1}–${endIndex} of ${totalItems} ${plural}`
+  }
+
+  return (
+    <div className="pg-root">
+      {/* Single shared live region — always mounted so screen readers pick up
+          text changes, regardless of which variant below is rendered. */}
+      <p role="status" aria-live="polite" aria-atomic="true" className="pg-status">
+        {statusText}
+      </p>
+
+      {!singlePage && isMobile && (
+        <div className="pg-loadmore">
+          {hasMore && (
+            <button type="button" className="pg-loadmore-btn" onClick={loadMore}>
+              Load more
+            </button>
+          )}
+        </div>
+      )}
+
+      {!singlePage && !isMobile && (
+        <nav aria-label="Pagination" className="pg-numbered">
+          <button
+            type="button"
+            className="pg-nav-btn"
+            onClick={() => setPage(page - 1)}
+            disabled={page <= 1}
+            aria-label="Previous page"
+          >
+            <span aria-hidden="true">‹</span> Prev
+          </button>
+
+          <ul className="pg-pages">
+            {getPageWindow(page, totalPages).map((entry, index) =>
+              entry === '…' ? (
+                <li key={`ellipsis-${index}`} className="pg-ellipsis" aria-hidden="true">
+                  …
+                </li>
+              ) : (
+                <li key={entry}>
+                  <button
+                    type="button"
+                    className={`pg-page-btn${entry === page ? ' pg-page-btn-active' : ''}`}
+                    aria-current={entry === page ? 'page' : undefined}
+                    aria-label={`Page ${entry}`}
+                    onClick={() => setPage(entry)}
+                  >
+                    {entry}
+                  </button>
+                </li>
+              ),
+            )}
+          </ul>
+
+          <button
+            type="button"
+            className="pg-nav-btn"
+            onClick={() => setPage(page + 1)}
+            disabled={page >= totalPages}
+            aria-label="Next page"
+          >
+            Next <span aria-hidden="true">›</span>
+          </button>
+
+          {showPageSizeSelector && (
+            <div className="pg-page-size">
+              <label htmlFor={pageSizeId}>Items per page</label>
+              <select
+                id={pageSizeId}
+                value={pageSize}
+                onChange={(e) => setPageSize(Number(e.target.value))}
+              >
+                {pageSizeOptions.map((size) => (
+                  <option key={size} value={size}>
+                    {size}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+        </nav>
+      )}
+    </div>
+  )
+}

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react'
+
+/** Matches the "mobile" cutoff already used elsewhere in src/index.css (max-width: 640px). */
+export const DEFAULT_MOBILE_BREAKPOINT = 640
+
+/**
+ * Tracks whether the viewport is at or below `breakpointPx` via matchMedia,
+ * following the same subscribe/addEventListener pattern as useTheme.ts.
+ */
+export function useIsMobile(breakpointPx: number = DEFAULT_MOBILE_BREAKPOINT): boolean {
+  const query = `(max-width: ${breakpointPx}px)`
+  const [isMobile, setIsMobile] = useState(() => window.matchMedia(query).matches)
+
+  useEffect(() => {
+    const mq = window.matchMedia(query)
+    const handler = () => setIsMobile(mq.matches)
+    handler()
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [query])
+
+  return isMobile
+}

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,0 +1,138 @@
+import { useCallback, useEffect } from 'react'
+import { useSearchParams } from 'react-router-dom'
+
+// ─── Public types ──────────────────────────────────────────────────────────
+
+export const DEFAULT_PAGE_SIZE_OPTIONS = [10, 25, 50] as const
+
+export type PaginationOptions = {
+  /** Default items per page when ?pageSize is absent or invalid. Default: 10 */
+  defaultPageSize?: number
+  /** Allowed page sizes — an invalid ?pageSize value falls back to defaultPageSize. */
+  pageSizeOptions?: readonly number[]
+}
+
+export type PaginationResult = {
+  page: number
+  pageSize: number
+  pageSizeOptions: readonly number[]
+  totalPages: number
+  /** 0-based, inclusive — start of the current numbered-page window. */
+  startIndex: number
+  /** 0-based, exclusive — end of the current numbered-page window. */
+  endIndex: number
+  /** 0-based, exclusive — end of the cumulative range for progressive ("load more") rendering. */
+  cumulativeEndIndex: number
+  /** Whether more items exist beyond cumulativeEndIndex. */
+  hasMore: boolean
+  setPage: (page: number) => void
+  setPageSize: (size: number) => void
+  loadMore: () => void
+}
+
+// ─── URL ↔ state bridge ─────────────────────────────────────────────────────
+
+/**
+ * URL contract:
+ *   ?page=<1-based int>   numbered variant: which page window is shown.
+ *                         progressive variant: how many pages have been loaded so far.
+ *   ?pageSize=<int>       items per page — must be one of `pageSizeOptions`.
+ *
+ * Both default silently (page 1 / defaultPageSize) when absent, non-numeric, or
+ * out of range — a hand-edited or stale URL never throws or shows a broken state.
+ */
+export function parsePaginationParams(
+  params: URLSearchParams,
+  { defaultPageSize = 10, pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS }: PaginationOptions = {},
+): { page: number; pageSize: number } {
+  const rawPageSize = Number(params.get('pageSize'))
+  const pageSize = pageSizeOptions.includes(rawPageSize) ? rawPageSize : defaultPageSize
+
+  const rawPage = Number(params.get('page'))
+  const page = Number.isInteger(rawPage) && rawPage >= 1 ? rawPage : 1
+
+  return { page, pageSize }
+}
+
+// ─── Hook ───────────────────────────────────────────────────────────────────
+
+export function usePagination(totalItems: number, options: PaginationOptions = {}): PaginationResult {
+  const { defaultPageSize = 10, pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS } = options
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const { page: requestedPage, pageSize } = parsePaginationParams(searchParams, {
+    defaultPageSize,
+    pageSizeOptions,
+  })
+
+  const totalPages = Math.max(1, Math.ceil(totalItems / pageSize))
+  const page = Math.min(requestedPage, totalPages)
+
+  // If the requested page is out of range (e.g. totalItems shrank), clamp the
+  // URL back to the last valid page rather than showing an empty page silently.
+  useEffect(() => {
+    if (requestedPage !== page) {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev)
+          next.set('page', String(page))
+          return next
+        },
+        { replace: true },
+      )
+    }
+  }, [requestedPage, page, setSearchParams])
+
+  const startIndex = (page - 1) * pageSize
+  const endIndex = Math.min(page * pageSize, totalItems)
+  const cumulativeEndIndex = Math.min(page * pageSize, totalItems)
+  const hasMore = cumulativeEndIndex < totalItems
+
+  const setPage = useCallback(
+    (next: number) => {
+      const clamped = Math.min(Math.max(1, Math.round(next)), totalPages)
+      setSearchParams(
+        (prev) => {
+          const p = new URLSearchParams(prev)
+          p.set('page', String(clamped))
+          return p
+        },
+        { replace: true },
+      )
+    },
+    [setSearchParams, totalPages],
+  )
+
+  const setPageSize = useCallback(
+    (size: number) => {
+      setSearchParams(
+        (prev) => {
+          const p = new URLSearchParams(prev)
+          p.set('pageSize', String(size))
+          p.set('page', '1')
+          return p
+        },
+        { replace: true },
+      )
+    },
+    [setSearchParams],
+  )
+
+  const loadMore = useCallback(() => {
+    setPage(page + 1)
+  }, [page, setPage])
+
+  return {
+    page,
+    pageSize,
+    pageSizeOptions,
+    totalPages,
+    startIndex,
+    endIndex,
+    cumulativeEndIndex,
+    hasMore,
+    setPage,
+    setPageSize,
+    loadMore,
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -43,6 +43,8 @@
   --radius-sm: 0.75rem;
   --radius-md: 1.25rem;
   --radius-lg: 1.75rem;
+  --focus-ring: 3px solid rgba(94, 234, 212, 0.92);
+  --focus-ring-offset: 3px;
 
   /* Density tokens */
   --density-gap: var(--space-4);
@@ -2961,6 +2963,181 @@ input {
   .sf-chips-actions {
     width: 100%;
     justify-content: flex-start;
+  }
+}
+
+/* ── Pagination / Load-more (pg-*) ────────────────────────────────────────
+ * Unified pagination pattern for long lists: numbered pages + page-size
+ * selector on dense/desktop screens, a single progressive "Load more"
+ * button on mobile. See docs/uiux/pagination-load-more-pattern.md.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+.pg-root {
+  display: grid;
+  gap: var(--density-row-gap);
+  margin-top: var(--density-gap);
+}
+
+.pg-status {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+/* ── Numbered variant ─────────────────────────────────────────────── */
+.pg-numbered {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.pg-nav-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  min-height: var(--density-touch-min);
+  padding: 0.4rem 0.875rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: rgba(148, 163, 184, 0.06);
+  color: var(--text);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    border-color 160ms ease,
+    background-color 160ms ease,
+    color 160ms ease;
+}
+
+.pg-nav-btn:hover:not(:disabled) {
+  border-color: rgba(173, 192, 217, 0.45);
+}
+
+.pg-nav-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.pg-pages {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.pg-page-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: var(--density-touch-min);
+  min-height: var(--density-touch-min);
+  padding: 0.3rem 0.6rem;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--muted);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    border-color 160ms ease,
+    background-color 160ms ease,
+    color 160ms ease;
+}
+
+.pg-page-btn:hover {
+  border-color: rgba(173, 192, 217, 0.45);
+  color: var(--text);
+}
+
+.pg-page-btn-active {
+  background: rgba(94, 234, 212, 0.1);
+  border-color: rgba(94, 234, 212, 0.48);
+  color: var(--accent);
+}
+
+.pg-ellipsis {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.5rem;
+  color: var(--muted);
+}
+
+.pg-page-size {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-inline-start: auto;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.pg-page-size select {
+  min-height: 2.25rem;
+  padding: 0.25rem 0.6rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: rgba(15, 23, 42, 0.82);
+  color: var(--text);
+  font: inherit;
+}
+
+.pg-page-size select:hover {
+  border-color: rgba(173, 192, 217, 0.45);
+}
+
+.pg-page-size select:focus {
+  outline: none;
+  border-color: var(--border-strong);
+  box-shadow: 0 0 0 0.25rem rgba(96, 165, 250, 0.16);
+}
+
+/* ── Progressive / Load-more variant ──────────────────────────────── */
+.pg-loadmore {
+  display: flex;
+  justify-content: center;
+}
+
+.pg-loadmore-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: var(--density-touch-min);
+  width: 100%;
+  max-width: 20rem;
+  padding: 0.6rem 1.25rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: rgba(148, 163, 184, 0.06);
+  color: var(--text);
+  font-size: 0.9rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    border-color 160ms ease,
+    background-color 160ms ease;
+}
+
+.pg-loadmore-btn:hover {
+  border-color: rgba(94, 234, 212, 0.48);
+  color: var(--accent);
+}
+
+/* ── Responsive ───────────────────────────────────────────────────── */
+@media (max-width: 640px) {
+  .pg-numbered {
+    justify-content: center;
+  }
+
+  .pg-page-size {
+    margin-inline-start: 0;
+    width: 100%;
+    justify-content: center;
   }
 }
 

--- a/src/pages/Attestations.test.tsx
+++ b/src/pages/Attestations.test.tsx
@@ -1,7 +1,9 @@
-import { describe, it, expect } from 'vitest'
+import { afterEach, describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import Attestations from './Attestations'
+
+afterEach(() => vi.restoreAllMocks())
 
 function renderPage() {
   return render(
@@ -9,6 +11,19 @@ function renderPage() {
       <Attestations />
     </MemoryRouter>,
   )
+}
+
+function mockViewport(isMobile: boolean) {
+  vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => ({
+    matches: isMobile,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia
 }
 
 describe('Attestations Page', () => {
@@ -42,5 +57,21 @@ describe('Attestations Page', () => {
     renderPage()
     const articles = screen.getAllByRole('article')
     expect(articles.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('shows the first page of results and numbered pagination on desktop', () => {
+    renderPage()
+    expect(screen.getByRole('navigation', { name: 'Pagination' })).toBeInTheDocument()
+    const statuses = screen.getAllByRole('status')
+    expect(statuses.some((el) => /showing 1–10 of 24 attestations/i.test(el.textContent ?? ''))).toBe(
+      true,
+    )
+  })
+
+  it('shows the progressive Load more control on narrow viewports', () => {
+    mockViewport(true)
+    renderPage()
+    expect(screen.getByRole('button', { name: 'Load more' })).toBeInTheDocument()
+    expect(screen.queryByRole('navigation', { name: 'Pagination' })).not.toBeInTheDocument()
   })
 })

--- a/src/pages/Attestations.tsx
+++ b/src/pages/Attestations.tsx
@@ -1,9 +1,8 @@
 import { Link } from 'react-router-dom'
-import { useSearchParams } from 'react-router-dom'
-import SearchFilter, { parseFilterState } from '../components/SearchFilter'
-import type { ChipDef, FilterState } from '../components/SearchFilter'
-
-// ─── Types ────────────────────────────────────────────────────────────────
+import { AttestationCalendar } from '../components/scheduling/AttestationCalendar'
+import Pagination from '../components/Pagination'
+import { usePagination } from '../hooks/usePagination'
+import { useIsMobile } from '../hooks/useIsMobile'
 
 // ─── Types ────────────────────────────────────────────────────────────────
 
@@ -57,9 +56,6 @@ const STATUS_META: Record<AttestationStatus, AttestationStatusMeta> = {
       </svg>
     ),
   },
-}
-
-const STATUS_STYLE: Record<AttestationStatus, { background: string; color: string; border: string }> = {
   verified: {
     label: "Verified",
     background: "var(--success-soft)",
@@ -113,8 +109,6 @@ const STATUS_STYLE: Record<AttestationStatus, { background: string; color: strin
     ),
   },
 };
-
-// ─── Helpers ──────────────────────────────────────────────────────────────
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
@@ -230,84 +224,6 @@ function EmptyState() {
       </div>
     </section>
   );
-}
-
-function NoResults({ onClearAll }: { onClearAll: () => void }) {
-  return (
-    <section
-      aria-label="No matching attestations"
-      style={{
-        marginTop: '1.75rem',
-        padding: '2rem 1.6rem',
-        background: 'var(--surface)',
-        borderRadius: 12,
-        border: '1px dashed var(--border)',
-        textAlign: 'center',
-      }}
-    >
-      <p style={{ margin: '0 0 1rem', fontSize: '1.05rem', fontWeight: 700 }}>
-        No attestations match your filters
-      </p>
-      <p style={{ margin: '0 0 1.25rem', color: 'var(--muted)', lineHeight: 1.6 }}>
-        Try adjusting your search term, removing a status filter, or widening
-        the date range.
-      </p>
-      <button
-        type="button"
-        onClick={onClearAll}
-        style={{
-          padding: '0.6rem 1.25rem',
-          borderRadius: 'var(--radius-sm)',
-          border: '1px solid var(--border)',
-          background: 'rgba(148, 163, 184, 0.08)',
-          color: 'var(--text)',
-          fontWeight: 600,
-          cursor: 'pointer',
-        }}
-      >
-        Clear all filters
-      </button>
-    </section>
-  )
-}
-
-function NoResults({ onClearAll }: { onClearAll: () => void }) {
-  return (
-    <section
-      aria-label="No matching attestations"
-      style={{
-        marginTop: '1.75rem',
-        padding: '2rem 1.6rem',
-        background: 'var(--surface)',
-        borderRadius: 12,
-        border: '1px dashed var(--border)',
-        textAlign: 'center',
-      }}
-    >
-      <p style={{ margin: '0 0 1rem', fontSize: '1.05rem', fontWeight: 700 }}>
-        No attestations match your filters
-      </p>
-      <p style={{ margin: '0 0 1.25rem', color: 'var(--muted)', lineHeight: 1.6 }}>
-        Try adjusting your search term, removing a status filter, or widening
-        the date range.
-      </p>
-      <button
-        type="button"
-        onClick={onClearAll}
-        style={{
-          padding: '0.6rem 1.25rem',
-          borderRadius: 'var(--radius-sm)',
-          border: '1px solid var(--border)',
-          background: 'rgba(148, 163, 184, 0.08)',
-          color: 'var(--text)',
-          fontWeight: 600,
-          cursor: 'pointer',
-        }}
-      >
-        Clear all filters
-      </button>
-    </section>
-  )
 }
 
 function TimelineRow({ item }: { item: AttestationListItem }) {
@@ -427,12 +343,17 @@ function TimelineRow({ item }: { item: AttestationListItem }) {
   );
 }
 
-// ─── Page ─────────────────────────────────────────────────────────────────
+// ─── Mock data ────────────────────────────────────────────────────────────
 
-import { AttestationCalendar } from '../components/scheduling/AttestationCalendar'
-
-export default function Attestations() {
-  const attestations: AttestationListItem[] = [
+/**
+ * Mock data — replace with a real API call. att-001 and att-002 are the
+ * canonical fixtures referenced by src/pages/Attestations.test.tsx and
+ * src/test/attestation-detail.test.tsx; additional synthetic runs are
+ * appended (older, descending dates) so the page has enough rows to
+ * exercise pagination realistically.
+ */
+function buildMockAttestations(): AttestationListItem[] {
+  const fixed: AttestationListItem[] = [
     {
       id: 'att-001',
       status: 'verified',
@@ -447,11 +368,38 @@ export default function Attestations() {
     },
   ]
 
+  const cycle: AttestationStatus[] = ['verified', 'verified', 'pending', 'failed']
+  const synthetic: AttestationListItem[] = Array.from({ length: 22 }, (_, i) => {
+    const n = i + 3
+    const monthsAgo = n
+    const date = new Date(Date.UTC(2026, 4 - monthsAgo, 15, 9, 10, 0))
+    return {
+      id: `att-${String(n).padStart(3, '0')}`,
+      status: cycle[i % cycle.length],
+      createdAt: date.toISOString(),
+      merkleRoot: `0x${n.toString(16).padStart(4, '0')}${'a1b2c3d4e5f6'.repeat(4)}`.slice(0, 66),
+    }
+  })
+
+  return [...fixed, ...synthetic]
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────
+
+export default function Attestations() {
+  const attestations = buildMockAttestations()
+
   // Mock scheduled runs for calendar indicators.
   const scheduledDates = [
     '2026-05-15',
     '2026-05-28',
   ]
+
+  const isMobile = useIsMobile()
+  const pagination = usePagination(attestations.length, { defaultPageSize: 10 })
+  const visibleAttestations = isMobile
+    ? attestations.slice(0, pagination.cumulativeEndIndex)
+    : attestations.slice(pagination.startIndex, pagination.endIndex)
 
   return (
     <div style={{ maxWidth: 1040 }}>
@@ -476,11 +424,18 @@ export default function Attestations() {
         {attestations.length === 0 ? (
           <EmptyState />
         ) : (
-          <ol style={{ margin: 0, padding: 0 }}>
-            {attestations.map((item) => (
-              <TimelineRow key={item.id} item={item} />
-            ))}
-          </ol>
+          <>
+            <ol style={{ margin: 0, padding: 0 }}>
+              {visibleAttestations.map((item) => (
+                <TimelineRow key={item.id} item={item} />
+              ))}
+            </ol>
+            <Pagination
+              pagination={pagination}
+              totalItems={attestations.length}
+              entityLabel="attestation"
+            />
+          </>
         )}
       </section>
     </div>

--- a/src/test/pagination.test.tsx
+++ b/src/test/pagination.test.tsx
@@ -1,0 +1,300 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes, useSearchParams } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import Pagination, { getPageWindow } from '../components/Pagination'
+import { parsePaginationParams, usePagination } from '../hooks/usePagination'
+import type { PaginationOptions } from '../hooks/usePagination'
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Renders the current URL search params in the DOM so tests can assert on them. */
+function ParamsDisplay() {
+  const [params] = useSearchParams()
+  return <div data-testid="params">{params.toString()}</div>
+}
+
+function params() {
+  return screen.getByTestId('params').textContent ?? ''
+}
+
+/** Mocks window.matchMedia so `useIsMobile` reports `matches` for every query. */
+function mockViewport(isMobile: boolean) {
+  vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => ({
+    matches: isMobile,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia
+}
+
+type HarnessProps = {
+  totalItems: number
+  options?: PaginationOptions
+  entityLabel?: string
+  showPageSizeSelector?: boolean
+}
+
+function Harness({ totalItems, options, entityLabel, showPageSizeSelector }: HarnessProps) {
+  const pagination = usePagination(totalItems, options)
+  return (
+    <>
+      <Pagination
+        pagination={pagination}
+        totalItems={totalItems}
+        entityLabel={entityLabel}
+        showPageSizeSelector={showPageSizeSelector}
+      />
+      <ParamsDisplay />
+    </>
+  )
+}
+
+function renderHarness(props: HarnessProps, initialSearch = '') {
+  return render(
+    <MemoryRouter initialEntries={[`/${initialSearch ? `?${initialSearch}` : ''}`]}>
+      <Routes>
+        <Route path="/" element={<Harness {...props} />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+// ─── parsePaginationParams ──────────────────────────────────────────────────
+
+describe('parsePaginationParams', () => {
+  it('defaults to page 1 and the default page size when params are absent', () => {
+    expect(parsePaginationParams(new URLSearchParams())).toEqual({ page: 1, pageSize: 10 })
+  })
+
+  it('parses valid page and pageSize params', () => {
+    expect(parsePaginationParams(new URLSearchParams('page=3&pageSize=25'))).toEqual({
+      page: 3,
+      pageSize: 25,
+    })
+  })
+
+  it('falls back to page 1 for non-numeric page', () => {
+    expect(parsePaginationParams(new URLSearchParams('page=abc')).page).toBe(1)
+  })
+
+  it('falls back to page 1 for a fractional page', () => {
+    expect(parsePaginationParams(new URLSearchParams('page=2.5')).page).toBe(1)
+  })
+
+  it('falls back to page 1 for a page below 1', () => {
+    expect(parsePaginationParams(new URLSearchParams('page=0')).page).toBe(1)
+    expect(parsePaginationParams(new URLSearchParams('page=-3')).page).toBe(1)
+  })
+
+  it('falls back to defaultPageSize for a pageSize not in pageSizeOptions', () => {
+    expect(parsePaginationParams(new URLSearchParams('pageSize=999')).pageSize).toBe(10)
+  })
+
+  it('respects a custom defaultPageSize and pageSizeOptions', () => {
+    const result = parsePaginationParams(new URLSearchParams(), {
+      defaultPageSize: 20,
+      pageSizeOptions: [20, 40],
+    })
+    expect(result).toEqual({ page: 1, pageSize: 20 })
+  })
+})
+
+// ─── getPageWindow ──────────────────────────────────────────────────────────
+
+describe('getPageWindow', () => {
+  it('returns the full sequential list when total fits without gaps', () => {
+    expect(getPageWindow(1, 1)).toEqual([1])
+    expect(getPageWindow(1, 2)).toEqual([1, 2])
+    expect(getPageWindow(4, 7)).toEqual([1, 2, 3, 4, 5, 6, 7])
+  })
+
+  it('shows a right ellipsis only when current is near the start', () => {
+    expect(getPageWindow(1, 10)).toEqual([1, 2, '…', 10])
+  })
+
+  it('shows a left ellipsis only when current is near the end', () => {
+    expect(getPageWindow(10, 10)).toEqual([1, '…', 9, 10])
+  })
+
+  it('shows both ellipses when current is in the middle of a long list', () => {
+    expect(getPageWindow(5, 10)).toEqual([1, '…', 4, 5, 6, '…', 10])
+  })
+
+  it('always includes the first and last page', () => {
+    const window_ = getPageWindow(50, 100)
+    expect(window_[0]).toBe(1)
+    expect(window_[window_.length - 1]).toBe(100)
+  })
+})
+
+// ─── Pagination — rendering ─────────────────────────────────────────────────
+
+describe('Pagination — single page', () => {
+  it('shows "Showing all N" and hides page controls when everything fits on one page', () => {
+    renderHarness({ totalItems: 5, options: { defaultPageSize: 10 } })
+    expect(screen.getByRole('status')).toHaveTextContent('Showing all 5 results')
+    expect(screen.queryByRole('navigation', { name: 'Pagination' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument()
+  })
+
+  it('shows "No results" when totalItems is 0', () => {
+    renderHarness({ totalItems: 0 })
+    expect(screen.getByRole('status')).toHaveTextContent('No results')
+  })
+
+  it('uses entityLabel in the announcement', () => {
+    renderHarness({ totalItems: 3, entityLabel: 'attestation' })
+    expect(screen.getByRole('status')).toHaveTextContent('Showing all 3 attestations')
+  })
+})
+
+describe('Pagination — numbered (desktop) variant', () => {
+  it('announces the current page range', () => {
+    renderHarness({ totalItems: 47, options: { defaultPageSize: 10 } })
+    expect(screen.getByRole('status')).toHaveTextContent('Showing 1–10 of 47 results')
+  })
+
+  it('renders a labelled navigation landmark', () => {
+    renderHarness({ totalItems: 47, options: { defaultPageSize: 10 } })
+    expect(screen.getByRole('navigation', { name: 'Pagination' })).toBeInTheDocument()
+  })
+
+  it('marks the current page with aria-current', () => {
+    renderHarness({ totalItems: 47, options: { defaultPageSize: 10 } })
+    expect(screen.getByRole('button', { name: 'Page 1' })).toHaveAttribute('aria-current', 'page')
+    expect(screen.getByRole('button', { name: 'Page 2' })).not.toHaveAttribute('aria-current')
+  })
+
+  it('disables Previous on the first page', () => {
+    renderHarness({ totalItems: 47, options: { defaultPageSize: 10 } })
+    expect(screen.getByRole('button', { name: 'Previous page' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Next page' })).not.toBeDisabled()
+  })
+
+  it('disables Next on the last page', () => {
+    renderHarness({ totalItems: 47, options: { defaultPageSize: 10 } }, 'page=5')
+    expect(screen.getByRole('button', { name: 'Next page' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Previous page' })).not.toBeDisabled()
+  })
+
+  it('clicking Next advances the ?page param', () => {
+    renderHarness({ totalItems: 47, options: { defaultPageSize: 10 } })
+    fireEvent.click(screen.getByRole('button', { name: 'Next page' }))
+    expect(params()).toContain('page=2')
+  })
+
+  it('clicking Previous goes back a page', () => {
+    renderHarness({ totalItems: 47, options: { defaultPageSize: 10 } }, 'page=3')
+    fireEvent.click(screen.getByRole('button', { name: 'Previous page' }))
+    expect(params()).toContain('page=2')
+  })
+
+  it('clicking a page number jumps directly to it', () => {
+    renderHarness({ totalItems: 47, options: { defaultPageSize: 10 } })
+    fireEvent.click(screen.getByRole('button', { name: 'Page 3' }))
+    expect(params()).toContain('page=3')
+  })
+
+  it('renders ellipses for a page count large enough to need windowing', () => {
+    renderHarness({ totalItems: 500, options: { defaultPageSize: 10 } }, 'page=25')
+    // 500 items / 10 per page = 50 pages; current=25 should show both gaps.
+    const list = screen.getByRole('navigation', { name: 'Pagination' })
+    expect(list.textContent).toContain('…')
+    expect(screen.getByRole('button', { name: 'Page 1' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Page 50' })).toBeInTheDocument()
+  })
+
+  it('shows an "Items per page" selector by default', () => {
+    renderHarness({ totalItems: 47, options: { defaultPageSize: 10 } })
+    expect(screen.getByLabelText('Items per page')).toBeInTheDocument()
+  })
+
+  it('hides the page-size selector when showPageSizeSelector is false', () => {
+    renderHarness({ totalItems: 47, options: { defaultPageSize: 10 }, showPageSizeSelector: false })
+    expect(screen.queryByLabelText('Items per page')).not.toBeInTheDocument()
+  })
+
+  it('changing the page size updates ?pageSize and resets ?page to 1', () => {
+    renderHarness({ totalItems: 47, options: { defaultPageSize: 10 } }, 'page=3')
+    fireEvent.change(screen.getByLabelText('Items per page'), { target: { value: '25' } })
+    expect(params()).toContain('pageSize=25')
+    expect(params()).toContain('page=1')
+  })
+
+  it('clamps an out-of-range ?page back to the last valid page', async () => {
+    renderHarness({ totalItems: 47, options: { defaultPageSize: 10 } }, 'page=999')
+    await act(async () => {})
+    expect(params()).toContain('page=5')
+    expect(screen.getByRole('button', { name: 'Page 5' })).toHaveAttribute('aria-current', 'page')
+  })
+})
+
+describe('Pagination — progressive (mobile) variant', () => {
+  it('shows a Load more button instead of numbered controls', () => {
+    mockViewport(true)
+    renderHarness({ totalItems: 47, options: { defaultPageSize: 10 } })
+    expect(screen.getByRole('button', { name: 'Load more' })).toBeInTheDocument()
+    expect(screen.queryByRole('navigation', { name: 'Pagination' })).not.toBeInTheDocument()
+  })
+
+  it('announces the cumulative count so far', () => {
+    mockViewport(true)
+    renderHarness({ totalItems: 47, options: { defaultPageSize: 10 } })
+    expect(screen.getByRole('status')).toHaveTextContent('Showing 10 of 47 results')
+  })
+
+  it('clicking Load more increases the cumulative count', () => {
+    mockViewport(true)
+    renderHarness({ totalItems: 47, options: { defaultPageSize: 10 } })
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
+    expect(params()).toContain('page=2')
+    expect(screen.getByRole('status')).toHaveTextContent('Showing 20 of 47 results')
+  })
+
+  it('hides the Load more button once everything is loaded', () => {
+    mockViewport(true)
+    renderHarness({ totalItems: 47, options: { defaultPageSize: 10 } }, 'page=5')
+    expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument()
+    expect(screen.getByRole('status')).toHaveTextContent('Showing all 47 results')
+  })
+
+  it('does not render a page-size selector', () => {
+    mockViewport(true)
+    renderHarness({ totalItems: 47, options: { defaultPageSize: 10 } })
+    expect(screen.queryByLabelText('Items per page')).not.toBeInTheDocument()
+  })
+})
+
+// ─── Accessibility ──────────────────────────────────────────────────────────
+
+describe('Pagination — accessibility', () => {
+  it('the live region exists before any interaction (not conditionally mounted)', () => {
+    renderHarness({ totalItems: 0 })
+    const status = screen.getByRole('status')
+    expect(status).toHaveAttribute('aria-live', 'polite')
+    expect(status).toHaveAttribute('aria-atomic', 'true')
+  })
+
+  it('ellipsis markers are hidden from assistive tech', () => {
+    renderHarness({ totalItems: 500, options: { defaultPageSize: 10 } }, 'page=25')
+    const nav = screen.getByRole('navigation', { name: 'Pagination' })
+    const ellipses = nav.querySelectorAll('[aria-hidden="true"]')
+    expect(Array.from(ellipses).some((el) => el.textContent === '…')).toBe(true)
+  })
+
+  it('Previous/Next buttons use disabled rather than aria-disabled', () => {
+    renderHarness({ totalItems: 47, options: { defaultPageSize: 10 } })
+    const prev = screen.getByRole('button', { name: 'Previous page' })
+    expect(prev).toHaveProperty('disabled', true)
+    expect(prev).not.toHaveAttribute('aria-disabled')
+  })
+})

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -3,3 +3,20 @@ import { afterEach } from 'vitest'
 import { cleanup } from '@testing-library/react'
 
 afterEach(cleanup)
+
+// jsdom does not implement matchMedia. Several hooks (useTheme, useIsMobile)
+// depend on it, so provide a safe default (no query ever matches) here so any
+// component using it can mount in tests. Individual tests that need a specific
+// breakpoint/theme result can vi.spyOn(window, 'matchMedia') to override it.
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia
+}


### PR DESCRIPTION
Closes #195.

## Summary

- Unified pagination pattern for long lists: numbered pages + a page-size selector on desktop, a single progressive "Load more" control on mobile — both driven by the **same** `?page`/`?pageSize` URL state (`usePagination`, `useIsMobile`, `Pagination`), applied to `src/pages/Attestations.tsx`.
- A single, always-mounted `role="status" aria-live="polite"` region announces the visible result range on every page change (`"Showing 11–20 of 47 attestations"`, `"Showing all 5 attestations"`, `"No attestations"`).
- Full design rationale, the URL-state contract, accessibility notes, responsive/RTL notes, and edge cases are documented in [`docs/uiux/pagination-load-more-pattern.md`](docs/uiux/pagination-load-more-pattern.md).

## Prerequisite fixes (in `src/pages/Attestations.tsx`, needed to touch this file at all)

This file had two pre-existing bugs that made it fail to compile/render before this PR — fixed as a necessary prerequisite, not scope creep:
- A duplicate `function NoResults(...)` declaration — a hard `SyntaxError` that made **both** `src/pages/Attestations.test.tsx` and `src/test/attestation-detail.test.tsx` fail to load at all.
- `STATUS_META` only defined the `pending` status; `verified`/`failed` metadata lived in a separate, differently-shaped, unused `STATUS_STYLE` constant, so `StatusBadge` threw a `TypeError` for any verified/failed item (including the page's own mock data).
- Removed now-dead, never-wired `SearchFilter`/`parseFilterState`/`ChipDef`/`FilterState` imports (unused, would fail lint) — wiring up search/filtering is out of scope for this issue.

Also added the `--focus-ring`/`--focus-ring-offset` custom properties to `:root` in `index.css` — the global `:focus-visible` rule referenced them but they were never defined anywhere, so **no element in the app had a visible keyboard focus ring**. Needed for the new pagination controls to actually meet the "must be accessible" requirement, and is a 2-line fix.

Also added a `window.matchMedia` polyfill to `src/test/setup.ts` — this jsdom version doesn't implement `matchMedia` at all, which crashed any test rendering a component that uses it (needed for `useIsMobile`).

## Scope note (disclosure)

This repo currently has unrelated, pre-existing failures on `main` (confirmed via `git stash` + running the suite against the unmodified branch): `App.tsx`/`Layout.tsx` don't compile due to an unrelated router regression, `RevenueSources.tsx` throws on an unimported `useToast`, `Settings.test.tsx` fails on a `LocalePickerField`/`IntlProvider` issue, and 3 pre-existing `AttestationDetail.tsx` tests fail (a `BackLink` component was superseded by `Breadcrumb` without removing the old "back to attestations" test expectations). None of these are touched by this PR and none were introduced by it — see the before/after numbers below.

## Test plan

- [x] `npx tsc --noEmit` — introduces **zero new errors**. All remaining errors are pre-existing and in files this PR doesn't touch (verified by listing every error and its file).
- [x] `npm run lint` — **zero errors, one warning** in changed files (`Pagination.tsx`'s `react-refresh/only-export-components` for exporting `getPageWindow` alongside the component — the same pre-existing warning `SearchFilter.tsx` already has for `parseFilterState`).
- [x] `npx vitest run` — before: 10 failed files / 191 failed test / 237 passed (428 total, 2 files failing to even load). After: **9 failed files / 297 passed** (491 total) — zero new failures, +38 new passing tests, and both previously-crashing suites now load and mostly pass (the 3 remaining `AttestationDetail.tsx` failures are pre-existing and unrelated, see above).
- [x] `src/test/pagination.test.tsx` — 36 cases, **100% statement/branch/function/line coverage** on `Pagination.tsx`, `usePagination.ts`, `useIsMobile.ts`.
- [x] `src/pages/Attestations.tsx` coverage (own test file): 93.5% statements / 75% branches / 96.7% lines — the only uncovered branch is the pre-existing `EmptyState` path (`attestations.length === 0`), which was already untested before this PR and is unrelated to pagination.
- [x] Edge cases covered by tests: single page (controls hidden), zero items, very many pages (ellipsis windowing on both sides), out-of-range `?page` clamping, mobile viewport (Load more, cumulative announcement, hides once fully loaded), page-size change resetting to page 1.
- [ ] Screenshots / axe DevTools scan — **not captured**. This change was authored and validated in a non-graphical environment with no browser available. Noted explicitly in the design doc; a reviewer with a running dev server should attach desktop/mobile screenshots and an axe scan per the checklist in `docs/uiux/pagination-load-more-pattern.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)