### PR TITLE
design: TOS versioned changelog modal

### DIFF
--- a/docs/uiux/tos-versioned-changelog-modal.md
+++ b/docs/uiux/tos-versioned-changelog-modal.md
@@ -1,0 +1,139 @@
+# Terms of Service Versioned Changelog Modal
+
+**Component:** `src/components/TermsOfServiceChangelogModal.tsx`  
+**Integration:** `src/pages/Signup.tsx`  
+**Standard:** WCAG 2.1 AA  
+**Issue:** `#263`
+
+---
+
+## Purpose
+
+When the Terms of Service changes, users should not be asked to accept a blank wall of legal text. The modal below presents:
+
+- the current policy version
+- the previous version for context
+- a short diff summary with explicit change types
+- links to download the full text in text and PDF form
+- a required acknowledgement checkbox before the primary action is enabled
+
+This keeps the legal update reviewable, keyboard-friendly, and consistent with the existing modal pattern used elsewhere in the product.
+
+---
+
+## Layout
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ Terms update                                  [Close]        │
+├──────────────────────────────────────────────────────────────┤
+│ Review the latest terms change log                           │
+│                                                              │
+│ v2.4.0  →  v2.3.0   Effective 2026-07-29                     │
+│                                                              │
+│ Download the complete policy                                 │
+│ [Download full text] [Download PDF]                          │
+│                                                              │
+│ What changed in this release                                 │
+│ ┌───────────┐ ┌───────────┐ ┌───────────┐                    │
+│ │ Added     │ │ Updated   │ │ Removed   │                    │
+│ │ Versioned │ │ Retention  │ │ Ambiguous │                    │
+│ │ changelog │ │ language   │ │ wording   │                    │
+│ └───────────┘ └───────────┘ └───────────┘                    │
+│                                                              │
+│ [ ] I have reviewed version v2.4.0 and understand it applies│
+│                                                              │
+│                 [Cancel] [Acknowledge and continue]          │
+└──────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Information Architecture
+
+- **Title**: “Review the latest terms change log”
+- **Version strip**: current version, previous version, and effective date
+- **Downloads**: full text and PDF links for offline review
+- **Diff summary**: three-card summary using `Added`, `Updated`, and `Removed`
+- **Acknowledgement**: a checkbox tied to the enabling state of the CTA
+- **CTA**: disabled until the checkbox is checked
+
+---
+
+## Accessibility
+
+- Uses `role="dialog"` and `aria-modal="true"`
+- Provides accessible naming via `aria-labelledby`
+- Provides a descriptive summary via `aria-describedby`
+- Traps focus within the modal while open
+- Restores focus to the trigger when closed
+- Supports `Escape` to close
+- Keeps the acknowledgement checkbox and CTA large enough for touch targets
+- Avoids colour-only meaning by pairing change type chips with text labels
+
+### Keyboard order
+
+1. Close button
+2. Download links
+3. Diff cards are read in document order
+4. Acknowledgement checkbox
+5. Cancel
+6. Acknowledge and continue
+
+---
+
+## Responsive Behaviour
+
+- On wide screens, the diff cards render in a three-column grid
+- On small screens, the cards stack into a single column
+- The modal width caps at a comfortable reading measure so legal text does not sprawl across the viewport
+- Footer buttons stack vertically on mobile, following the existing modal pattern
+
+---
+
+## Data Contract
+
+```ts
+interface TermsChange {
+  kind: 'Added' | 'Updated' | 'Removed'
+  title: string
+  detail: string
+}
+
+interface TermsOfServiceChangelogModalProps {
+  open: boolean
+  currentVersion: string
+  previousVersion: string
+  effectiveDate: string
+  summary: string
+  changes: TermsChange[]
+  fullTextHref: string
+  pdfHref: string
+  onAcknowledge: (version: string) => void
+  onClose: () => void
+}
+```
+
+---
+
+## Validation Notes
+
+- The modal is covered by unit tests for open/closed rendering, download links, acknowledgement gating, and Escape-to-close behavior.
+- The signup screen is covered by an integration test that verifies the create-account action remains disabled until acknowledgement is completed.
+- Manual axe review should confirm:
+  - no dialog name/description violations
+  - no focus escape outside the overlay
+  - no contrast regressions in the diff chips or warning strip
+
+---
+
+## Review Checklist
+
+- [ ] Review button opens the modal
+- [ ] Diff cards clearly communicate what changed
+- [ ] Download links work for text and PDF outputs
+- [ ] Checkbox is required before acknowledging
+- [ ] CTA remains disabled until the checkbox is checked
+- [ ] Escape and close button both dismiss the modal
+- [ ] Focus returns to the trigger after close
+

--- a/public/legal/terms-of-service-v2-4-0.pdf
+++ b/public/legal/terms-of-service-v2-4-0.pdf
@@ -1,0 +1,24 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj<< /Type /Catalog /Pages 2 0 R >>endobj
+2 0 obj<< /Type /Pages /Kids [3 0 R] /Count 1 >>endobj
+3 0 obj<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>endobj
+4 0 obj<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>endobj
+5 0 obj<< /Length 208 >>stream
+BT /F1 24 Tf 72 720 Td (Veritasor Terms of Service v2.4.0) Tj ET
+BT /F1 12 Tf 72 690 Td (Effective date: 2026-07-29) Tj ET
+BT /F1 12 Tf 72 660 Td (Download the full text file for the full policy copy.) Tj ET
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000062 00000 n 
+0000000117 00000 n 
+0000000241 00000 n 
+0000000309 00000 n 
+trailer<< /Size 6 /Root 1 0 R >>
+startxref
+565
+%%EOF

--- a/public/legal/terms-of-service-v2-4-0.txt
+++ b/public/legal/terms-of-service-v2-4-0.txt
@@ -1,0 +1,11 @@
+Veritasor Terms of Service v2.4.0
+
+Effective date: 2026-07-29
+
+Summary of this release:
+- Added a versioned changelog flow for policy reviews.
+- Clarified data retention timing for user, audit, and support records.
+- Replaced broad third-party sharing language with named disclosure categories.
+
+This text file is a lightweight download for offline review.
+

--- a/src/components/TermsOfServiceChangelogModal.test.tsx
+++ b/src/components/TermsOfServiceChangelogModal.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import TermsOfServiceChangelogModal from './TermsOfServiceChangelogModal'
+
+const baseProps = {
+  currentVersion: 'v2.4.0',
+  previousVersion: 'v2.3.0',
+  effectiveDate: '2026-07-29',
+  summary: 'We updated the terms to make policy changes easier to review.',
+  changes: [
+    {
+      kind: 'Added' as const,
+      title: 'Versioned changelog',
+      detail: 'The modal now highlights policy diffs.',
+    },
+    {
+      kind: 'Updated' as const,
+      title: 'Retention language',
+      detail: 'Retention timing is now stated directly.',
+    },
+    {
+      kind: 'Removed' as const,
+      title: 'Ambiguous wording',
+      detail: 'Broad sharing language has been replaced with named disclosures.',
+    },
+  ],
+  fullTextHref: '/legal/terms-of-service-v2-4-0.txt',
+  pdfHref: '/legal/terms-of-service-v2-4-0.pdf',
+}
+
+describe('TermsOfServiceChangelogModal', () => {
+  it('does not render when closed', () => {
+    render(
+      <TermsOfServiceChangelogModal
+        open={false}
+        onAcknowledge={vi.fn()}
+        onClose={vi.fn()}
+        {...baseProps}
+      />,
+    )
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('shows versioned diff content and requires acknowledgement', () => {
+    const onAcknowledge = vi.fn()
+    render(
+      <TermsOfServiceChangelogModal
+        open
+        onAcknowledge={onAcknowledge}
+        onClose={vi.fn()}
+        {...baseProps}
+      />,
+    )
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText(/review the latest terms change log/i)).toBeInTheDocument()
+    expect(screen.getByText('v2.4.0')).toBeInTheDocument()
+    expect(screen.getByText('v2.3.0')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /download full text/i })).toHaveAttribute(
+      'href',
+      baseProps.fullTextHref,
+    )
+    expect(screen.getByRole('link', { name: /download pdf/i })).toHaveAttribute(
+      'href',
+      baseProps.pdfHref,
+    )
+    expect(screen.getByRole('button', { name: /acknowledge and continue/i })).toBeDisabled()
+
+    fireEvent.click(screen.getByLabelText(/i have reviewed version v2\.4\.0/i))
+    fireEvent.click(screen.getByRole('button', { name: /acknowledge and continue/i }))
+
+    expect(onAcknowledge).toHaveBeenCalledWith('v2.4.0')
+  })
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn()
+    render(
+      <TermsOfServiceChangelogModal
+        open
+        onAcknowledge={vi.fn()}
+        onClose={onClose}
+        {...baseProps}
+      />,
+    )
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/src/components/TermsOfServiceChangelogModal.tsx
+++ b/src/components/TermsOfServiceChangelogModal.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useId, useRef, useState } from 'react'
+
+const FOCUSABLE =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+function formatDate(dateIso: string) {
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(new Date(`${dateIso}T00:00:00`))
+}
+
+export interface TermsChange {
+  kind: 'Added' | 'Updated' | 'Removed'
+  title: string
+  detail: string
+}
+
+export interface TermsOfServiceChangelogModalProps {
+  open: boolean
+  currentVersion: string
+  previousVersion: string
+  effectiveDate: string
+  summary: string
+  changes: TermsChange[]
+  fullTextHref: string
+  pdfHref: string
+  onAcknowledge: (version: string) => void
+  onClose: () => void
+}
+
+export default function TermsOfServiceChangelogModal({
+  open,
+  currentVersion,
+  previousVersion,
+  effectiveDate,
+  summary,
+  changes,
+  fullTextHref,
+  pdfHref,
+  onAcknowledge,
+  onClose,
+}: TermsOfServiceChangelogModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLElement | null>(null)
+  const titleId = useId()
+  const descId = useId()
+  const summaryId = useId()
+  const acknowledgeId = useId()
+  const [acknowledged, setAcknowledged] = useState(false)
+
+  useEffect(() => {
+    if (open) {
+      triggerRef.current = document.activeElement as HTMLElement
+      setAcknowledged(false)
+      dialogRef.current?.focus()
+    } else {
+      triggerRef.current?.focus()
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+        return
+      }
+
+      if (e.key !== 'Tab') return
+
+      const focusable = Array.from(dialogRef.current!.querySelectorAll<HTMLElement>(FOCUSABLE))
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [open, onClose])
+
+  function handleBackdropClick() {
+    onClose()
+  }
+
+  function handleAcknowledge() {
+    if (!acknowledged) return
+    onAcknowledge(currentVersion)
+  }
+
+  if (!open) return null
+
+  return (
+    <div className="modal-backdrop" onClick={handleBackdropClick}>
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={`${descId} ${summaryId}`}
+        className="modal-dialog tos-dialog"
+        tabIndex={-1}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="modal-header">
+          <div className="tos-header-copy">
+            <p className="tos-eyebrow">Terms update</p>
+            <h2 id={titleId} className="modal-title">
+              Review the latest terms change log
+            </h2>
+          </div>
+          <button type="button" className="modal-close" aria-label="Close dialog" onClick={onClose}>
+            <span aria-hidden="true">✕</span>
+          </button>
+        </div>
+
+        <div className="modal-body tos-body">
+          <p id={descId} className="modal-description">
+            {summary}
+          </p>
+
+          <div className="tos-version-strip" aria-label="Terms version summary">
+            <span className="tos-version-pill tos-version-pill-current">{currentVersion}</span>
+            <span className="tos-version-arrow" aria-hidden="true">
+              →
+            </span>
+            <span className="tos-version-pill">{previousVersion}</span>
+            <span className="tos-effective-date">
+              Effective <time dateTime={effectiveDate}>{formatDate(effectiveDate)}</time>
+            </span>
+          </div>
+
+          <section className="tos-downloads" aria-labelledby={summaryId}>
+            <div className="tos-section-header">
+              <h3 id={summaryId} className="tos-section-title">
+                Download the complete policy
+              </h3>
+              <p className="tos-section-copy">
+                Keep the full text for your records or share it with legal, compliance, or procurement.
+              </p>
+            </div>
+            <div className="tos-download-links">
+              <a href={fullTextHref} className="tos-download-link" download>
+                Download full text
+              </a>
+              <a href={pdfHref} className="tos-download-link" download>
+                Download PDF
+              </a>
+            </div>
+          </section>
+
+          <section className="tos-diff" aria-labelledby="tos-diff-title">
+            <div className="tos-section-header">
+              <h3 id="tos-diff-title" className="tos-section-title">
+                What changed in this release
+              </h3>
+              <p className="tos-section-copy">
+                The summary below highlights the most review-worthy additions, clarifications, and removals.
+              </p>
+            </div>
+
+            <ul className="tos-change-list">
+              {changes.map((change) => (
+                <li key={`${change.kind}-${change.title}`} className="tos-change-card">
+                  <div className={`tos-change-kind tos-change-kind-${change.kind.toLowerCase()}`}>
+                    {change.kind}
+                  </div>
+                  <h4 className="tos-change-title">{change.title}</h4>
+                  <p className="tos-change-detail">{change.detail}</p>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <label className="tos-acknowledge" htmlFor={acknowledgeId}>
+            <input
+              id={acknowledgeId}
+              type="checkbox"
+              checked={acknowledged}
+              onChange={(e) => setAcknowledged(e.target.checked)}
+            />
+            <span>
+              I have reviewed version {currentVersion} and understand it applies before I can continue.
+            </span>
+          </label>
+        </div>
+
+        <div className="modal-footer tos-footer">
+          <button type="button" className="modal-btn modal-btn-cancel" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="modal-btn modal-btn-confirm tos-confirm"
+            onClick={handleAcknowledge}
+            disabled={!acknowledged}
+            aria-busy={false}
+          >
+            Acknowledge and continue
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1093,6 +1093,226 @@ input {
   color: rgba(4, 17, 31, 0.6);
 }
 
+.tos-dialog {
+  width: min(760px, 100%);
+}
+
+.tos-body {
+  gap: 1rem;
+}
+
+.tos-header-copy {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.tos-eyebrow {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.tos-version-strip {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.875rem 1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.tos-version-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2rem;
+  padding: 0.25rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-size: 0.8rem;
+  font-weight: 700;
+  background: var(--surface-strong);
+}
+
+.tos-version-pill-current {
+  border-color: rgba(94, 234, 212, 0.35);
+  background: rgba(94, 234, 212, 0.1);
+  color: var(--accent);
+}
+
+.tos-version-arrow {
+  color: var(--muted);
+  font-weight: 700;
+}
+
+.tos-effective-date {
+  margin-left: auto;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.tos-section-header {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.tos-section-title {
+  margin: 0;
+  color: var(--text);
+  font-size: 0.98rem;
+  font-weight: 700;
+}
+
+.tos-section-copy {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
+.tos-downloads,
+.tos-diff {
+  display: grid;
+  gap: 0.8rem;
+  padding: 1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.52);
+}
+
+.tos-download-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.tos-download-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 0.6rem 0.9rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(173, 192, 217, 0.4);
+  color: var(--text);
+  background: rgba(148, 163, 184, 0.08);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.tos-download-link:hover {
+  border-color: var(--accent);
+  text-decoration: none;
+}
+
+.tos-change-list {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.tos-change-card {
+  display: grid;
+  gap: 0.55rem;
+  padding: 0.9rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--surface-strong);
+}
+
+.tos-change-kind {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  min-height: 1.75rem;
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.tos-change-kind-added {
+  color: #dcfff1;
+  border: 1px solid rgba(52, 211, 153, 0.35);
+  background: rgba(52, 211, 153, 0.1);
+}
+
+.tos-change-kind-updated {
+  color: #e0f2ff;
+  border: 1px solid rgba(96, 165, 250, 0.35);
+  background: rgba(96, 165, 250, 0.12);
+}
+
+.tos-change-kind-removed {
+  color: #ffd7dd;
+  border: 1px solid rgba(251, 113, 133, 0.35);
+  background: rgba(251, 113, 133, 0.1);
+}
+
+.tos-change-title {
+  margin: 0;
+  color: var(--text);
+  font-size: 0.92rem;
+  font-weight: 700;
+}
+
+.tos-change-detail {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.86rem;
+  line-height: 1.55;
+}
+
+.tos-acknowledge {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.9rem 1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(251, 191, 36, 0.35);
+  background: rgba(251, 191, 36, 0.08);
+  color: #fff1c4;
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
+.tos-acknowledge input {
+  width: var(--space-4);
+  height: var(--space-4);
+  margin-top: 0.1rem;
+  accent-color: var(--accent);
+  flex-shrink: 0;
+}
+
+.tos-acknowledgement {
+  display: grid;
+  gap: 0.875rem;
+}
+
+.tos-acknowledgement-copy {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.tos-review-button {
+  width: 100%;
+}
+
+.tos-confirm:disabled {
+  background: rgba(94, 234, 212, 0.22);
+  color: rgba(4, 17, 31, 0.58);
+}
+
 @media (max-width: 480px) {
   .modal-footer {
     flex-direction: column-reverse;
@@ -1105,6 +1325,14 @@ input {
   .attest-summary-row {
     grid-template-columns: 1fr;
     gap: 0.125rem;
+  }
+
+  .tos-change-list {
+    grid-template-columns: 1fr;
+  }
+
+  .tos-effective-date {
+    margin-left: 0;
   }
 }
 

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import AuthShell from "../components/AuthShell";
+import TermsOfServiceChangelogModal from "../components/TermsOfServiceChangelogModal";
 
 const highlights = [
   "Clear field grouping keeps legal, team, and security details easy to scan",
@@ -6,7 +8,38 @@ const highlights = [
   "Responsive spacing keeps the full flow usable without horizontal scrolling",
 ];
 
+const CURRENT_TOS_VERSION = "v2.4.0";
+const PREVIOUS_TOS_VERSION = "v2.3.0";
+const TOS_EFFECTIVE_DATE = "2026-07-29";
+const TOS_SUMMARY =
+  "We updated the Terms of Service to make version history explicit, surface the most relevant policy diffs, and make it easier to review the full agreement before continuing.";
+
+const TOS_CHANGES = [
+  {
+    kind: "Added" as const,
+    title: "Versioned changelog and comparison view",
+    detail:
+      "Every update now includes a release label plus a human-readable diff summary so legal and compliance reviewers can spot policy changes faster.",
+  },
+  {
+    kind: "Updated" as const,
+    title: "Data retention and export language",
+    detail:
+      "Retention timing now states how long profile, audit, and support records are kept before deletion or anonymization.",
+  },
+  {
+    kind: "Removed" as const,
+    title: "Ambiguous third-party sharing wording",
+    detail:
+      "The policy no longer uses broad phrasing around sharing and instead names the operational disclosures that actually apply.",
+  },
+];
+
 export default function Signup() {
+  const [tosModalOpen, setTosModalOpen] = useState(false);
+  const [acknowledgedVersion, setAcknowledgedVersion] = useState<string | null>(null);
+
+  const hasAcknowledgedCurrentTerms = acknowledgedVersion === CURRENT_TOS_VERSION;
 
   return (
     <AuthShell
@@ -20,6 +53,21 @@ export default function Signup() {
       sideDescription="Typography, spacing, and button hierarchy are shared across all authentication screens so engineers can extend the flow without inventing new patterns."
       sideHighlights={highlights}
     >
+      <TermsOfServiceChangelogModal
+        open={tosModalOpen}
+        currentVersion={CURRENT_TOS_VERSION}
+        previousVersion={PREVIOUS_TOS_VERSION}
+        effectiveDate={TOS_EFFECTIVE_DATE}
+        summary={TOS_SUMMARY}
+        changes={TOS_CHANGES}
+        fullTextHref="/legal/terms-of-service-v2-4-0.txt"
+        pdfHref="/legal/terms-of-service-v2-4-0.pdf"
+        onAcknowledge={(version) => {
+          setAcknowledgedVersion(version);
+          setTosModalOpen(false);
+        }}
+        onClose={() => setTosModalOpen(false)}
+      />
       <form className="auth-form">
         <div className="auth-grid">
           <div className="auth-input-group">
@@ -87,16 +135,26 @@ export default function Signup() {
           <p className="auth-strength-copy">Strong enough for a production workspace</p>
         </div>
 
-        <label className="auth-checkbox">
-          <input type="checkbox" />
-          <span>
-            I agree to the terms, privacy policy, and audit logging
-            requirements.
-          </span>
-        </label>
+        <div className="auth-message auth-message-warning tos-acknowledgement" role="note">
+          <div className="tos-acknowledgement-copy">
+            <strong>Updated terms need review</strong>
+            <span>
+              Version {CURRENT_TOS_VERSION} replaces {PREVIOUS_TOS_VERSION}. Acknowledge the changelog before creating your account.
+            </span>
+          </div>
+          <button type="button" className="auth-button auth-button-secondary tos-review-button" onClick={() => setTosModalOpen(true)}>
+            Review changes
+          </button>
+        </div>
+
+        {hasAcknowledgedCurrentTerms && (
+          <div className="auth-message auth-message-success" role="status" aria-live="polite">
+            Terms {CURRENT_TOS_VERSION} acknowledged.
+          </div>
+        )}
 
         <div className="auth-actions">
-          <button type="submit" className="auth-button auth-button-primary">
+          <button type="submit" className="auth-button auth-button-primary" disabled={!hasAcknowledgedCurrentTerms}>
             Create account
           </button>
           <button type="button" className="auth-button auth-button-secondary">

--- a/src/test/auth-screens.test.tsx
+++ b/src/test/auth-screens.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter } from 'react-router-dom'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import type { ReactElement } from 'react'
 import { describe, expect, it } from 'vitest'
 import Login from '../pages/Login'
@@ -64,6 +64,33 @@ describe('authentication screens visual system', () => {
     expect(
       screen.getByRole('button', { name: /create account/i }),
     ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /create account/i }),
+    ).toBeDisabled()
+    expect(
+      screen.getByRole('button', { name: /review changes/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('opens the terms changelog modal and enables signup after acknowledgement', () => {
+    renderWithRouter(<Signup />)
+
+    fireEvent.click(screen.getByRole('button', { name: /review changes/i }))
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /download full text/i })).toHaveAttribute(
+      'href',
+      '/legal/terms-of-service-v2-4-0.txt',
+    )
+    expect(screen.getByRole('button', { name: /acknowledge and continue/i })).toBeDisabled()
+
+    fireEvent.click(screen.getByLabelText(/i have reviewed version v2\.4\.0/i))
+    fireEvent.click(screen.getByRole('button', { name: /acknowledge and continue/i }))
+
+    expect(
+      screen.getByRole('button', { name: /create account/i }),
+    ).toBeEnabled()
+    expect(screen.getByText(/terms v2\.4\.0 acknowledged/i)).toBeInTheDocument()
   })
 
   it('renders forgot password messaging and recovery actions', () => {


### PR DESCRIPTION
## What changed
- Added a reusable Terms of Service versioned changelog modal with diff cards, version context, download links, and a required acknowledgement checkbox.
- Wired the signup flow to require acknowledgement before continuing so updated terms must be reviewed first.
- Added design-system documentation plus downloadable policy text/PDF assets for the modal.
- Added unit and integration tests for the modal and signup gate.

## Validation
- `git diff --check`
- Attempted `npm exec vitest run src/components/TermsOfServiceChangelogModal.test.tsx src/test/auth-screens.test.tsx` but the environment is missing installed dependencies (`vitest` / `@vitejs/plugin-react`).
- Attempted `npm exec eslint ...` but the environment is missing installed dependencies (`@eslint/js`).
- Validated the generated PDF artifact with `pypdf`.

Closes #263

closes #263 