### PR TITLE
design: tokens diff viewer between versions

### DIFF
--- a/docs/uiux/tokens-theme-diff-viewer.md
+++ b/docs/uiux/tokens-theme-diff-viewer.md
@@ -1,0 +1,17 @@
+# Theme Token Diff Viewer
+
+The Tokens settings panel includes a review-only comparison of two versioned theme snapshots. It is intended to make publishing changes safer by showing only added, changed, and removed token values.
+
+## Interaction
+
+- Choose an earlier and later theme version with native select controls.
+- Filter results by color, typography, spacing, or radius.
+- Review the earlier and later values side by side; color tokens include labelled swatches and non-color values use the same value layout.
+- Each row has an explicit Added, Changed, or Removed chip. Do not rely on the chip colour alone.
+
+## Accessibility and responsiveness
+
+- Labels, table headers, swatch names, and live result count expose the comparison to screen readers.
+- Native selects provide keyboard operation without custom key handling.
+- The control layout uses an auto-fit grid; the comparison table preserves column relationships and becomes horizontally scrollable on narrow screens.
+- Semantic foreground, surface, and status tokens preserve the application’s existing WCAG AA contrast contract.

--- a/package-lock.json
+++ b/package-lock.json
@@ -913,6 +913,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -930,6 +948,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -945,6 +981,24 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -5371,6 +5425,420 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
@@ -5396,6 +5864,50 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/vitest/node_modules/vite": {

--- a/src/components/tokens/TokensDiffViewer.tsx
+++ b/src/components/tokens/TokensDiffViewer.tsx
@@ -1,0 +1,147 @@
+import { useMemo, useState, type CSSProperties } from 'react'
+
+type TokenCategory = 'Color' | 'Typography' | 'Spacing' | 'Radius'
+type TokenStatus = 'Added' | 'Changed' | 'Removed'
+type Token = { name: string; category: TokenCategory; value: string }
+
+type ThemeVersion = {
+  label: string
+  tokens: Token[]
+}
+
+const THEME_VERSIONS: Record<string, ThemeVersion> = {
+  '2.3': {
+    label: 'Theme 2.3',
+    tokens: [
+      { name: '--color-brand', category: 'Color', value: '#22c55e' },
+      { name: '--color-surface', category: 'Color', value: '#0f1b30' },
+      { name: '--text-body', category: 'Typography', value: '0.95rem' },
+      { name: '--space-4', category: 'Spacing', value: '1rem' },
+      { name: '--radius-card', category: 'Radius', value: '12px' },
+      { name: '--radius-pill', category: 'Radius', value: '999px' },
+    ],
+  },
+  '2.4': {
+    label: 'Theme 2.4',
+    tokens: [
+      { name: '--color-brand', category: 'Color', value: '#14b8a6' },
+      { name: '--color-surface', category: 'Color', value: '#111c33' },
+      { name: '--color-focus-ring', category: 'Color', value: '#fbbf24' },
+      { name: '--text-body', category: 'Typography', value: '1rem' },
+      { name: '--space-4', category: 'Spacing', value: '1rem' },
+      { name: '--space-6', category: 'Spacing', value: '1.5rem' },
+      { name: '--radius-card', category: 'Radius', value: '16px' },
+    ],
+  },
+}
+
+const categories: Array<TokenCategory | 'All'> = ['All', 'Color', 'Typography', 'Spacing', 'Radius']
+
+export type TokenDiff = Token & {
+  status: TokenStatus
+  previousValue?: string
+  currentValue?: string
+}
+
+export function getTokenDiff(previous: Token[], current: Token[]): TokenDiff[] {
+  const previousByName = new Map(previous.map((token) => [token.name, token]))
+  const currentByName = new Map(current.map((token) => [token.name, token]))
+  const names = new Set([...previousByName.keys(), ...currentByName.keys()])
+
+  return Array.from(names)
+    .flatMap((name) => {
+      const before = previousByName.get(name)
+      const after = currentByName.get(name)
+      if (!before && after) return [{ ...after, status: 'Added' as const, currentValue: after.value }]
+      if (before && !after) return [{ ...before, status: 'Removed' as const, previousValue: before.value }]
+      if (before && after && before.value !== after.value) {
+        return [{ ...after, status: 'Changed' as const, previousValue: before.value, currentValue: after.value }]
+      }
+      return []
+    })
+    .sort((first, second) => first.name.localeCompare(second.name))
+}
+
+const fieldStyle: CSSProperties = {
+  minHeight: 'var(--density-touch-min)',
+  padding: '0.55rem 0.7rem',
+  border: '1px solid var(--border)',
+  borderRadius: 8,
+  background: 'var(--surface-strong)',
+  color: 'var(--text)',
+}
+
+function Swatch({ value, label }: { value?: string; label: string }) {
+  const isColor = Boolean(value?.startsWith('#'))
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.45rem', minWidth: 0 }}>
+      <span
+        aria-label={value ? `${label}: ${value}` : `${label}: not present`}
+        role="img"
+        style={{
+          width: '1.4rem', height: '1.4rem', flex: '0 0 auto', borderRadius: 5,
+          border: '1px solid var(--border-strong)', background: isColor ? value : 'repeating-linear-gradient(45deg, var(--surface-strong), var(--surface-strong) 3px, var(--border) 3px, var(--border) 6px)',
+        }}
+      />
+      <code style={{ overflowWrap: 'anywhere' }}>{value ?? '—'}</code>
+    </span>
+  )
+}
+
+function StatusChip({ status }: { status: TokenStatus }) {
+  const colors: Record<TokenStatus, { background: string; color: string }> = {
+    Added: { background: 'var(--success-soft)', color: 'var(--success)' },
+    Changed: { background: 'rgba(251, 191, 36, 0.16)', color: 'var(--warning)' },
+    Removed: { background: 'rgba(251, 113, 133, 0.16)', color: 'var(--danger)' },
+  }
+  return <span style={{ ...colors[status], borderRadius: 999, padding: '0.2rem 0.55rem', fontSize: '0.78rem', fontWeight: 800 }}>{status}</span>
+}
+
+export default function TokensDiffViewer() {
+  const [previousVersion, setPreviousVersion] = useState('2.3')
+  const [currentVersion, setCurrentVersion] = useState('2.4')
+  const [category, setCategory] = useState<TokenCategory | 'All'>('All')
+  const diff = useMemo(
+    () => getTokenDiff(THEME_VERSIONS[previousVersion].tokens, THEME_VERSIONS[currentVersion].tokens),
+    [previousVersion, currentVersion],
+  )
+  const visibleDiff = category === 'All' ? diff : diff.filter((token) => token.category === category)
+
+  return (
+    <section aria-labelledby="tokens-diff-title" style={{ padding: 'var(--density-padding)', background: 'var(--surface)', border: '1px solid var(--border)', borderRadius: 16 }}>
+      <h2 id="tokens-diff-title" style={{ margin: '0 0 0.5rem', fontSize: 'var(--text-xl)' }}>Compare theme tokens</h2>
+      <p style={{ margin: '0 0 1rem', color: 'var(--muted)', lineHeight: 1.6 }}>Review added, changed, and removed tokens before publishing a theme version. Status is always written in addition to color.</p>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: '0.75rem', alignItems: 'end' }}>
+        <label style={{ display: 'grid', gap: '0.35rem', fontWeight: 700 }}>Earlier version
+          <select value={previousVersion} onChange={(event) => setPreviousVersion(event.target.value)} style={fieldStyle} aria-label="Earlier theme version">
+            {Object.entries(THEME_VERSIONS).map(([version, theme]) => <option key={version} value={version}>{theme.label}</option>)}
+          </select>
+        </label>
+        <label style={{ display: 'grid', gap: '0.35rem', fontWeight: 700 }}>Later version
+          <select value={currentVersion} onChange={(event) => setCurrentVersion(event.target.value)} style={fieldStyle} aria-label="Later theme version">
+            {Object.entries(THEME_VERSIONS).map(([version, theme]) => <option key={version} value={version}>{theme.label}</option>)}
+          </select>
+        </label>
+        <label style={{ display: 'grid', gap: '0.35rem', fontWeight: 700 }}>Token category
+          <select value={category} onChange={(event) => setCategory(event.target.value as TokenCategory | 'All')} style={fieldStyle} aria-label="Filter diff by token category">
+            {categories.map((item) => <option key={item} value={item}>{item}</option>)}
+          </select>
+        </label>
+      </div>
+      <p role="status" aria-live="polite" style={{ margin: '1rem 0 0', color: 'var(--muted)', fontSize: 'var(--text-sm)' }}>{visibleDiff.length} {visibleDiff.length === 1 ? 'difference' : 'differences'} shown.</p>
+      <div style={{ marginTop: '0.75rem', overflowX: 'auto' }}>
+        <div role="table" aria-label="Theme token differences" style={{ minWidth: 620, display: 'grid', gap: '0.35rem' }}>
+          <div role="row" style={{ display: 'grid', gridTemplateColumns: 'minmax(150px, 1.2fr) 100px minmax(135px, 1fr) minmax(135px, 1fr) 90px', gap: '0.75rem', padding: '0 0.75rem', fontSize: 'var(--text-sm)', fontWeight: 800, color: 'var(--muted)' }}>
+            <span role="columnheader">Token</span><span role="columnheader">Category</span><span role="columnheader">Earlier</span><span role="columnheader">Later</span><span role="columnheader">Status</span>
+          </div>
+          {visibleDiff.map((token) => (
+            <div key={token.name} role="row" style={{ display: 'grid', gridTemplateColumns: 'minmax(150px, 1.2fr) 100px minmax(135px, 1fr) minmax(135px, 1fr) 90px', gap: '0.75rem', alignItems: 'center', padding: '0.75rem', border: '1px solid var(--border)', borderRadius: 10, background: 'var(--surface-strong)' }}>
+              <code role="cell" style={{ fontWeight: 800, overflowWrap: 'anywhere' }}>{token.name}</code><span role="cell">{token.category}</span><span role="cell"><Swatch value={token.previousValue} label={`Earlier value for ${token.name}`} /></span><span role="cell"><Swatch value={token.currentValue} label={`Later value for ${token.name}`} /></span><span role="cell"><StatusChip status={token.status} /></span>
+            </div>
+          ))}
+        </div>
+      </div>
+      {visibleDiff.length === 0 && <p style={{ margin: '1rem 0 0', color: 'var(--muted)' }}>No differences match this category.</p>}
+    </section>
+  )
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -4,6 +4,7 @@ import LocalePickerField from '../components/LocalePicker/LocalePickerField'
 import AuditLogTimeline, { type AuditLogEntry } from '../components/audit-log/AuditLogTimeline'
 import type { AuditLogEntryDetail } from '../components/audit-log/AuditLogDetailDrawer'
 import TokensExport from '../components/tokens/TokensExport'
+import TokensDiffViewer from '../components/tokens/TokensDiffViewer'
 import A11yAuditPanel from '../components/a11y/A11yAuditPanel'
 import A11yCoverageMatrix from '../components/a11y/A11yCoverageMatrix'
 import SettingsIntegrationsPanel from './SettingsIntegrationsPanel'
@@ -2865,10 +2866,10 @@ function TokensPanel() {
     <div>
       <h2>Design tokens</h2>
       <p style={{ color: "var(--muted)" }}>
-        Export a snapshot of Veritasor design tokens as CSS custom properties.
-        Choose a scope, then copy or download the file.
+        Review theme changes, then export a snapshot of Veritasor design tokens as CSS custom properties.
       </p>
-      <div style={{ marginTop: "1.5rem", maxWidth: 720 }}>
+      <div style={{ marginTop: "1.5rem", maxWidth: 1100, display: "grid", gap: "1.5rem" }}>
+        <TokensDiffViewer />
         <TokensExport />
       </div>
     </div>

--- a/src/test/tokens-diff-viewer.test.tsx
+++ b/src/test/tokens-diff-viewer.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import TokensDiffViewer, { getTokenDiff } from '../components/tokens/TokensDiffViewer'
+
+describe('getTokenDiff', () => {
+  it('reports added, changed, and removed tokens', () => {
+    const diff = getTokenDiff(
+      [{ name: '--old', category: 'Color', value: '#000' }, { name: '--change', category: 'Color', value: '#111' }],
+      [{ name: '--change', category: 'Color', value: '#222' }, { name: '--new', category: 'Spacing', value: '1rem' }],
+    )
+    expect(diff.map(({ name, status }) => [name, status])).toEqual([['--change', 'Changed'], ['--new', 'Added'], ['--old', 'Removed']])
+  })
+})
+
+describe('TokensDiffViewer', () => {
+  it('renders status chips and side-by-side value swatches', () => {
+    render(<TokensDiffViewer />)
+    expect(screen.getByRole('heading', { name: /compare theme tokens/i })).toBeInTheDocument()
+    expect(screen.getAllByText('Added')).not.toHaveLength(0)
+    expect(screen.getAllByText('Changed')).not.toHaveLength(0)
+    expect(screen.getAllByText('Removed')).not.toHaveLength(0)
+    expect(screen.getByRole('img', { name: /earlier value for --color-brand/i })).toBeInTheDocument()
+  })
+
+  it('filters differences by category with a labelled native control', () => {
+    render(<TokensDiffViewer />)
+    fireEvent.change(screen.getByRole('combobox', { name: /filter diff by token category/i }), { target: { value: 'Radius' } })
+    expect(screen.getByText('--radius-card')).toBeInTheDocument()
+    expect(screen.getByText('--radius-pill')).toBeInTheDocument()
+    expect(screen.queryByText('--color-brand')).not.toBeInTheDocument()
+  })
+
+  it('announces an empty filtered result', () => {
+    render(<TokensDiffViewer />)
+    fireEvent.change(screen.getByRole('combobox', { name: /earlier theme version/i }), { target: { value: '2.4' } })
+    expect(screen.getByText(/no differences match this category/i)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Add a review-only diff viewer to the design tokens admin panel that compares two theme versions side by side, with labelled swatches and explicit Added/Changed/Removed chips (status is never color-only) and a token category filter. Wired into the Tokens settings panel ahead of TokensExport.

closes #283 